### PR TITLE
Fix incorrect early free of str when reading ole fields

### DIFF
--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -1661,7 +1661,7 @@ SQLRETURN SQL_API SQLGetData(
 				strcpy(sqlState, "01004"); // truncated
 				return SQL_SUCCESS_WITH_INFO;
 			}
-			stmt->pos = 0;
+			stmt->pos = len;
 			free(str);
 			str = NULL;
 			break;

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -1649,14 +1649,19 @@ SQLRETURN SQL_API SQLGetData(
 				return SQL_SUCCESS_WITH_INFO;
 			}
 
-			memcpy(rgbValue, str + stmt->pos, MIN(len - stmt->pos, cbValueMax-1));
-			((char *)rgbValue)[MIN(len - stmt->pos, cbValueMax-1)] = '\0';
-			stmt->pos += MIN(len - stmt->pos, cbValueMax-1);
-			if (cbValueMax - 1 < len - stmt->pos) {
+			const int totalSizeRemaining = len - stmt->pos;
+			const int partsRemain = cbValueMax - 1 < totalSizeRemaining;
+			const int sizeToReadThisPart = partsRemain ? cbValueMax - 1 : totalSizeRemaining;
+			memcpy(rgbValue, str + stmt->pos, sizeToReadThisPart);
+
+			((char *)rgbValue)[sizeToReadThisPart] = '\0';
+			if (partsRemain) {
+			        stmt->pos += cbValueMax - 1;
 				if (col->col_type != MDB_OLE) { free(str); str = NULL; }
 				strcpy(sqlState, "01004"); // truncated
 				return SQL_SUCCESS_WITH_INFO;
 			}
+			stmt->pos = 0;
 			free(str);
 			str = NULL;
 			break;


### PR DESCRIPTION
I'm not sure if this fix is correct, but following #6 I'm seeing that the str ole data is being cleared one read too soon. I believe this is happening because the `stmr->pos` position is being increment before the check whether buffer size is sufficient to store the remaining data, so it incorrectly assumes that one extra read has occurred and consequently frees `str`. 

(FWIW - I'm still seeing the deadlock on master. Did you hit this on the unixodbc builds?)