### PR TITLE
Correctly return len of character data when SQLColAttributes is called with SQL_COLUMN_TYPE_NAME

### DIFF
--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -839,7 +839,7 @@ SQLRETURN SQL_API SQLColAttributes(
 		{
 			const char *type_name = _odbc_get_client_type_name(col);
 			if (type_name)
-				snprintf(rgbDesc, cbDescMax, "%s", type_name);
+				*pcbDesc = snprintf(rgbDesc, cbDescMax, "%s", type_name);
 			break;
 		}
 		case SQL_COLUMN_LENGTH:


### PR DESCRIPTION
See  https://docs.microsoft.com/en-us/sql/odbc/reference/syntax/sqlcolattribute-function?view=sql-server-ver15

"StringLengthPtr
[Output] Pointer to a buffer in which to return the total number of bytes (excluding the null-termination byte for character data) available to return in *CharacterAttributePtr."