### PR TITLE
Don't crash when a table can't be read for some reason

### DIFF
--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -1337,6 +1337,11 @@ SQLRETURN SQL_API SQLColumns(
 		if (g_ascii_strcasecmp((char*)szTableName, entry->object_name) != 0)
 			continue;
 		table = mdb_read_table(entry);
+		if ( !table )
+		{
+			LogError ("Could not read table '%s'", szTableName);
+			return SQL_ERROR;
+		}
 		mdb_read_columns(table);
 		for (j=0; j<table->num_cols; j++) {
 			col = g_ptr_array_index(table->columns, j);

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -1334,7 +1334,7 @@ SQLRETURN SQL_API SQLColumns(
 	for (i=0; i<mdb->num_catalog; i++) {
      		entry = g_ptr_array_index(mdb->catalog, i);
 		/* TODO: Do more advanced matching */
-		if (g_ascii_strcasecmp((char*)szTableName, entry->object_name) != 0)
+		if (entry->object_type != MDB_TABLE || g_ascii_strcasecmp((char*)szTableName, entry->object_name) != 0)
 			continue;
 		table = mdb_read_table(entry);
 		if ( !table )


### PR DESCRIPTION
E.g. many of the tables in the nwind.mdb database return null to mdb_read_table for some reason. Better not to crash here, but we should investigate the underlying reason behind the failure...