### PR TITLE
Attempt to make the ODBC driver thread-safe

### DIFF
--- a/include/mdbfakeglib.h
+++ b/include/mdbfakeglib.h
@@ -121,7 +121,7 @@ typedef struct GOptionContext {
 /* string functions */
 void *g_memdup(const void *src, size_t len);
 int g_str_equal(const void *str1, const void *str2);
-char **g_strsplit(const char *haystack, const char *needle, int something);
+char **g_strsplit(const char *haystack, const char *needle, int max_tokens);
 void g_strfreev(char **dir);
 char *g_strconcat(const char *first, ...);
 char *g_strdup(const char *src);

--- a/src/libmdb/fakeglib.c
+++ b/src/libmdb/fakeglib.c
@@ -22,7 +22,8 @@ int g_str_equal(const void *str1, const void *str2) {
     return strcmp(str1, str2) == 0;
 }
 
-char **g_strsplit(const char *haystack, const char *needle, int something) {
+// max_tokens not yet implemented
+char **g_strsplit(const char *haystack, const char *needle, int max_tokens) {
     char **ret = NULL;
     char *found = NULL;
     size_t components = 2; // last component + terminating NULL

--- a/src/odbc/connectparams.c
+++ b/src/odbc/connectparams.c
@@ -201,7 +201,7 @@ void DumpParams (ConnectParams* params, FILE* output)
 
 gchar* ExtractDSN (ConnectParams* params, const gchar* connectString)
 {
-   char *p, *q, *s;
+   char *p, *q;
 
    if (!params)
       return NULL;
@@ -233,7 +233,7 @@ gchar* ExtractDSN (ConnectParams* params, const gchar* connectString)
 
 gchar* ExtractDBQ (ConnectParams* params, const gchar* connectString)
 {
-   char *p, *q, *s;
+   char *p, *q;
 
    if (!params)
       return NULL;

--- a/src/odbc/connectparams.c
+++ b/src/odbc/connectparams.c
@@ -43,9 +43,6 @@
 #define FILENAME_MAX 512
 #endif
 
-#define max_line 256
-static char line[max_line];
-
 static guint HashFunction (gconstpointer key);
 
 static void visit (gpointer key, gpointer value, gpointer user_data);
@@ -225,16 +222,11 @@ gchar* ExtractDSN (ConnectParams* params, const gchar* connectString)
    while (isspace(*q))
      q++;
    /*
-    * Copy the DSN value to a buffer
-    */
-   s = line;
-   while (*q && *q != ';')
-      *s++ = *q++;
-   *s = '\0';
-   /*
     * Save it as a string in the params object
     */
-   params->dsnName = g_string_assign (params->dsnName, line);
+   char **components = g_strsplit(q, ";", 2);
+   params->dsnName = g_string_assign(params->dsnName, components[0]);
+   g_strfreev(components);
 
    return params->dsnName->str;   
 }
@@ -262,16 +254,11 @@ gchar* ExtractDBQ (ConnectParams* params, const gchar* connectString)
    while (isspace(*q))
      q++;
    /*
-    * Copy the DSN value to a buffer
-    */
-   s = line;
-   while (*q && *q != ';')
-      *s++ = *q++;
-   *s = '\0';
-   /*
     * Save it as a string in the params object
     */
-   params->dsnName = g_string_assign (params->dsnName, line);
+   char **components = g_strsplit(q, ";", 2);
+   params->dsnName = g_string_assign(params->dsnName, components[0]);
+   g_strfreev(components);
 
    return params->dsnName->str;
 }

--- a/src/odbc/mdbodbc.h
+++ b/src/odbc/mdbodbc.h
@@ -37,6 +37,7 @@ extern "C" {
 
 struct _henv {
 	GPtrArray *connections;
+    char sqlState[6];
 };
 struct _hdbc {
 	struct _henv *henv;
@@ -44,6 +45,7 @@ struct _hdbc {
 	ConnectParams* params;
 	GPtrArray *statements;
     char lastError[256];
+    char sqlState[6];
 #ifdef ENABLE_ODBC_W
     iconv_t iconv_in;
     iconv_t iconv_out;
@@ -57,6 +59,7 @@ struct _hstmt {
 	 */
 	char query[4096];
     char lastError[256];
+    char sqlState[6];
 	struct _sql_bind_info *bind_head;
 	int rows_affected;
 	int icol; /* SQLGetData: last column */

--- a/src/odbc/mdbodbc.h
+++ b/src/odbc/mdbodbc.h
@@ -60,6 +60,8 @@ struct _hstmt {
 	char query[4096];
     char lastError[256];
     char sqlState[6];
+    char *ole_str;
+    size_t ole_len;
 	struct _sql_bind_info *bind_head;
 	int rows_affected;
 	int icol; /* SQLGetData: last column */

--- a/src/odbc/mdbodbc.h
+++ b/src/odbc/mdbodbc.h
@@ -43,6 +43,7 @@ struct _hdbc {
 	MdbSQL *sqlconn;
 	ConnectParams* params;
 	GPtrArray *statements;
+    char lastError[256];
 #ifdef ENABLE_ODBC_W
     iconv_t iconv_in;
     iconv_t iconv_out;

--- a/src/odbc/mdbodbc.h
+++ b/src/odbc/mdbodbc.h
@@ -56,6 +56,7 @@ struct _hstmt {
 	 * please make dynamic before checking in 
 	 */
 	char query[4096];
+    char lastError[256];
 	struct _sql_bind_info *bind_head;
 	int rows_affected;
 	int icol; /* SQLGetData: last column */

--- a/src/odbc/mdbodbc.h
+++ b/src/odbc/mdbodbc.h
@@ -43,6 +43,10 @@ struct _hdbc {
 	MdbSQL *sqlconn;
 	ConnectParams* params;
 	GPtrArray *statements;
+#ifdef ENABLE_ODBC_W
+    iconv_t iconv_in;
+    iconv_t iconv_out;
+#endif
 };
 struct _hstmt {
 	MdbSQL *sql;

--- a/src/odbc/odbc.c
+++ b/src/odbc/odbc.c
@@ -147,10 +147,6 @@ static int sqlwlen(SQLWCHAR *p){
 }
 #endif // ENABLE_ODBC_W
 
-/* The SQL engine is presently non-reenterrant and non-thread safe.  
-   See SQLExecute for details.
-*/
-
 static void LogError (const char* format, ...)
 {
    /*


### PR DESCRIPTION
I'm not sure if this is a complete solution - some of the global state has been moved to thread-local storage. So passing an ODBC handle across threads may have unexpected results. But at least it's not global state.

Each ODBC handle now has its own `iconv_t` object.

See #23