### PR TITLE
If no MDBOPTS environment variable is set, then default to setting the MDB_USE_INDEX option

### DIFF
--- a/src/libmdb/options.c
+++ b/src/libmdb/options.c
@@ -77,6 +77,8 @@ load_options()
 			opt = strtok(NULL,":");
 		}
     }
+    else if ( !optset )
+       opts |= MDB_USE_INDEX;
 	optset = 1;
 }
 int

--- a/src/libmdb/options.c
+++ b/src/libmdb/options.c
@@ -55,7 +55,7 @@ load_options()
 	char *opt;
 	char *s;
 
-    if (!optset && (s=getenv("MDBOPTS"))) {
+	if (!optset && (s=getenv("MDBOPTS"))) {
 		opt = strtok(s, ":");
 		while (opt) {
         	if (!strcmp(opt, "use_index")) opts |= MDB_USE_INDEX;
@@ -76,9 +76,10 @@ load_options()
 			}
 			opt = strtok(NULL,":");
 		}
-    }
-    else if ( !optset )
-       opts |= MDB_USE_INDEX;
+	}
+	else if ( !optset ) {
+		opts |= MDB_USE_INDEX;
+	}
 	optset = 1;
 }
 int


### PR DESCRIPTION
I'm not sure if not using the index by default was a deliberate decision, or whether this is just a bug. But in my (admittedly limited) tests the index support is working OK.