### PR TITLE
[API break] Make date/boolean formats thread safe

### DIFF
--- a/include/mdbtools.h
+++ b/include/mdbtools.h
@@ -277,6 +277,9 @@ typedef struct {
 	char		*backend_name;
 	MdbFormatConstants *fmt;
 	MdbStatistics *stats;
+    char date_fmt[64];
+    const char *boolean_false_value;
+    const char *boolean_true_value;
 #ifdef HAVE_ICONV
 	iconv_t	iconv_in;
 	iconv_t	iconv_out;
@@ -506,8 +509,9 @@ int mdb_col_disp_size(MdbColumn *col);
 size_t mdb_ole_read_next(MdbHandle *mdb, MdbColumn *col, void *ole_ptr);
 size_t mdb_ole_read(MdbHandle *mdb, MdbColumn *col, void *ole_ptr, size_t chunk_size);
 void* mdb_ole_read_full(MdbHandle *mdb, MdbColumn *col, size_t *size);
-void mdb_set_date_fmt(const char *);
-void mdb_set_boolean_fmt_words(void);
+void mdb_set_date_fmt(MdbHandle *mdb, const char *);
+void mdb_set_boolean_fmt_words(MdbHandle *mdb);
+void mdb_set_boolean_fmt_numbers(MdbHandle *mdb);
 int mdb_read_row(MdbTableDef *table, unsigned int row);
 
 /* dump.c */

--- a/src/libmdb/file.c
+++ b/src/libmdb/file.c
@@ -179,6 +179,8 @@ MdbHandle *mdb_open(const char *filename, MdbFileFlags flags)
 
 	mdb = (MdbHandle *) g_malloc0(sizeof(MdbHandle));
 	mdb_set_default_backend(mdb, "access");
+    mdb_set_date_fmt(mdb, "%x %X");
+    mdb_set_boolean_fmt_numbers(mdb);
 #ifdef HAVE_ICONV
 	mdb->iconv_in = (iconv_t)-1;
 	mdb->iconv_out = (iconv_t)-1;

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -159,16 +159,10 @@ main(int argc, char **argv)
 	if (insert_dialect)
 		header_row = 0;
 
-	if (date_fmt)
-		mdb_set_date_fmt(date_fmt);
-
 	if (null_text)
 		null_text = escapes(null_text);
 	else
 		null_text = g_strdup("");
-
-	if (boolean_words)
-		mdb_set_boolean_fmt_words();
 
 	if (str_bin_mode) {
 		if (!strcmp(str_bin_mode, "strip"))
@@ -188,6 +182,12 @@ main(int argc, char **argv)
 		/* Don't bother clean up memory before exit */
 		exit(1);
 	}
+
+	if (date_fmt)
+		mdb_set_date_fmt(mdb, date_fmt);
+
+	if (boolean_words)
+		mdb_set_boolean_fmt_words(mdb);
 
 	if (insert_dialect)
 		if (!mdb_set_default_backend(mdb, insert_dialect)) {


### PR DESCRIPTION
Store the preferred date and boolean formats in the `MdbHandle` rather than in global memory.

Also set some static arrays to `const`.