### PR TITLE
Remove references to dmalloc

### DIFF
--- a/src/libmdb/catalog.c
+++ b/src/libmdb/catalog.c
@@ -18,10 +18,6 @@
 
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 char *
 mdb_get_objtype_string(int obj_type)
 {

--- a/src/libmdb/data.c
+++ b/src/libmdb/data.c
@@ -21,10 +21,6 @@
 #include <math.h>
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 #define OFFSET_MASK 0x1fff
 
 char *mdb_money_to_string(MdbHandle *mdb, int start);

--- a/src/libmdb/dump.c
+++ b/src/libmdb/dump.c
@@ -21,10 +21,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 void mdb_buffer_dump(const void* buf, off_t start, size_t len)
 {
 	char asc[20];

--- a/src/libmdb/file.c
+++ b/src/libmdb/file.c
@@ -19,10 +19,6 @@
 #include <inttypes.h>
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 /*
 typedef struct {
 	int		pg_size;

--- a/src/libmdb/iconv.c
+++ b/src/libmdb/iconv.c
@@ -19,10 +19,6 @@
 #include <errno.h>
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 #ifndef MIN
 #define MIN(a,b) (a>b ? b : a)
 #endif

--- a/src/libmdb/index.c
+++ b/src/libmdb/index.c
@@ -21,10 +21,6 @@
 #include <mswstr/mswstr.h>
 #endif
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 MdbIndexPage *mdb_index_read_bottom_pg(MdbHandle *mdb, MdbIndex *idx, MdbIndexChain *chain);
 MdbIndexPage *mdb_chain_add_page(MdbHandle *mdb, MdbIndexChain *chain, guint32 pg);
 

--- a/src/libmdb/like.c
+++ b/src/libmdb/like.c
@@ -20,10 +20,6 @@
 #include <string.h>
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 /**
  * mdb_like_cmp
  * @s: String to search within.

--- a/src/libmdb/map.c
+++ b/src/libmdb/map.c
@@ -18,10 +18,6 @@
 
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 static gint32
 mdb_map_find_next0(MdbHandle *mdb, unsigned char *map, unsigned int map_sz, guint32 start_pg)
 {

--- a/src/libmdb/money.c
+++ b/src/libmdb/money.c
@@ -19,10 +19,6 @@
 #include <stdio.h>
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 #define MAX_MONEY_PRECISION   20
 #define MAX_NUMERIC_PRECISION 40
 /* 

--- a/src/libmdb/options.c
+++ b/src/libmdb/options.c
@@ -22,10 +22,6 @@
 #include <stdlib.h>
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 #define DEBUG 1
 
 static unsigned long opts;

--- a/src/libmdb/sargs.c
+++ b/src/libmdb/sargs.c
@@ -29,9 +29,6 @@
 
 #include <time.h>
 #include "mdbtools.h"
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
 
 void
 mdb_sql_walk_tree(MdbSargNode *node, MdbSargTreeFunc func, gpointer data)

--- a/src/libmdb/stats.c
+++ b/src/libmdb/stats.c
@@ -18,10 +18,6 @@
 
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 /**
  * mdb_stats_on:
  * @mdb: Handle to the (open) MDB file to collect stats on.

--- a/src/libmdb/table.c
+++ b/src/libmdb/table.c
@@ -18,11 +18,6 @@
 
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
-
 static gint mdb_col_comparer(MdbColumn **a, MdbColumn **b)
 {
 	if ((*a)->col_num > (*b)->col_num)

--- a/src/libmdb/worktable.c
+++ b/src/libmdb/worktable.c
@@ -18,10 +18,6 @@
 
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 /*
  * Temp table routines.  These are currently used to generate mock results for
  * commands like "list tables" and "describe table"

--- a/src/libmdb/write.c
+++ b/src/libmdb/write.c
@@ -21,11 +21,6 @@
 #include <inttypes.h>
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
-
 //static int mdb_copy_index_pg(MdbTableDef *table, MdbIndex *idx, MdbIndexPage *ipg);
 static int mdb_add_row_to_leaf_pg(MdbTableDef *table, MdbIndex *idx, MdbIndexPage *ipg, MdbField *idx_fields, guint32 pgnum, guint16 rownum);
 

--- a/src/sql/mdbsql.c
+++ b/src/sql/mdbsql.c
@@ -20,10 +20,6 @@
 #define _XOPEN_SOURCE
 #include "mdbsql.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 #ifdef HAVE_WORDEXP_H
 #define HAVE_WORDEXP
 #include <wordexp.h>

--- a/src/util/mdb-array.c
+++ b/src/util/mdb-array.c
@@ -21,10 +21,6 @@
 
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 int
 main (int argc, char **argv)
 {

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -18,10 +18,6 @@
 
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 #undef MDB_BIND_SIZE
 #define MDB_BIND_SIZE 200000
 

--- a/src/util/mdb-header.c
+++ b/src/util/mdb-header.c
@@ -22,10 +22,6 @@
 #include <string.h>
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 void copy_header (FILE *f)
 {
  fprintf (f, "/******************************************************************/\n");

--- a/src/util/mdb-parsecsv.c
+++ b/src/util/mdb-parsecsv.c
@@ -24,10 +24,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 #define FILENAMESIZE 128
 #define BUFFERSIZE 4096
 #define LF 10

--- a/src/util/mdb-schema.c
+++ b/src/util/mdb-schema.c
@@ -19,10 +19,6 @@
 /* this utility dumps the schema for an existing database */
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 int
 main (int argc, char **argv)
 {

--- a/src/util/mdb-sql.c
+++ b/src/util/mdb-sql.c
@@ -47,10 +47,6 @@ extern void clear_history ();
 #include <string.h>
 #include "mdbsql.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 void dump_results(FILE *out, MdbSQL *sql, char *delimiter);
 void dump_results_pp(FILE *out, MdbSQL *sql);
 

--- a/src/util/mdb-tables.c
+++ b/src/util/mdb-tables.c
@@ -20,10 +20,6 @@
 
 #include "mdbtools.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 struct type_struct {
 	char *name;
 	int value;

--- a/src/util/mdb-ver.c
+++ b/src/util/mdb-ver.c
@@ -21,10 +21,6 @@
 #include "mdbver.h"
 #include "mdbprivate.h"
 
-#ifdef DMALLOC
-#include "dmalloc.h"
-#endif
-
 int
 main(int argc, char **argv)
 {


### PR DESCRIPTION
There are more modern tools for memory debugging, get rid of `DMALLOC` crap in the source code.

I've left one reference in backend.c to prevent a merge conflict but this can be removed later.