### PR TITLE
New mdb_set_bind_size function overrides MDB_BIND_SIZE

### DIFF
--- a/include/mdbtools.h
+++ b/include/mdbtools.h
@@ -54,7 +54,7 @@
 #define MDB_MAX_IDX_COLS 10
 #define MDB_CATALOG_PG 18
 #define MDB_MEMO_OVERHEAD 12
-#define MDB_BIND_SIZE 16384
+#define MDB_BIND_SIZE 16384 // override with mdb_set_bind_size(MdbHandle*, size_t)
 
 // This attribute is not supported by all compilers:
 // M$VC see http://stackoverflow.com/questions/1113409/attribute-constructor-equivalent-in-vc
@@ -269,6 +269,7 @@ typedef struct {
 	unsigned char pg_buf[MDB_PGSIZE];
 	unsigned char alt_pg_buf[MDB_PGSIZE];
 	MdbFormatConstants *fmt;
+    size_t bind_size;
     char date_fmt[64];
     const char *boolean_false_value;
     const char *boolean_true_value;
@@ -512,6 +513,7 @@ int mdb_col_disp_size(MdbColumn *col);
 size_t mdb_ole_read_next(MdbHandle *mdb, MdbColumn *col, void *ole_ptr);
 size_t mdb_ole_read(MdbHandle *mdb, MdbColumn *col, void *ole_ptr, size_t chunk_size);
 void* mdb_ole_read_full(MdbHandle *mdb, MdbColumn *col, size_t *size);
+void mdb_set_bind_size(MdbHandle *mdb, size_t bind_size);
 void mdb_set_date_fmt(MdbHandle *mdb, const char *);
 void mdb_set_boolean_fmt_words(MdbHandle *mdb);
 void mdb_set_boolean_fmt_numbers(MdbHandle *mdb);

--- a/src/libmdb/backend.c
+++ b/src/libmdb/backend.c
@@ -623,7 +623,7 @@ mdb_get_relationships(MdbHandle *mdb, const gchar *dbnamespace, const char* tabl
 
 		mdb_read_columns(mdb->relationships_table);
 		for (i=0;i<5;i++) {
-			bound[i] = (char *) g_malloc0(MDB_BIND_SIZE);
+			bound[i] = (char *) g_malloc0(mdb->bind_size);
 		}
 		mdb_bind_column_by_name(mdb->relationships_table, "szColumn", bound[0], NULL);
 		mdb_bind_column_by_name(mdb->relationships_table, "szObject", bound[1], NULL);

--- a/src/libmdb/file.c
+++ b/src/libmdb/file.c
@@ -174,6 +174,7 @@ static MdbHandle *mdb_handle_from_stream(FILE *stream, MdbFileFlags flags) {
 	MdbHandle *mdb = (MdbHandle *) g_malloc0(sizeof(MdbHandle));
 	mdb_set_default_backend(mdb, "access");
     mdb_set_date_fmt(mdb, "%x %X");
+    mdb_set_bind_size(mdb, MDB_BIND_SIZE);
     mdb_set_boolean_fmt_numbers(mdb);
 #ifdef HAVE_ICONV
 	mdb->iconv_in = (iconv_t)-1;

--- a/src/util/mdb-export.c
+++ b/src/util/mdb-export.c
@@ -18,8 +18,7 @@
 
 #include "mdbtools.h"
 
-#undef MDB_BIND_SIZE
-#define MDB_BIND_SIZE 200000
+#define EXPORT_BIND_SIZE 200000
 
 #define is_quote_type(x) (x==MDB_TEXT || x==MDB_OLE || x==MDB_MEMO || x==MDB_DATETIME || x==MDB_BINARY || x==MDB_REPID)
 #define is_binary_type(x) (x==MDB_OLE || x==MDB_BINARY || x==MDB_REPID)
@@ -191,6 +190,8 @@ main(int argc, char **argv)
 	if (boolean_words)
 		mdb_set_boolean_fmt_words(mdb);
 
+    mdb_set_bind_size(mdb, EXPORT_BIND_SIZE);
+
 	if (insert_dialect)
 		if (!mdb_set_default_backend(mdb, insert_dialect)) {
 			fputs("Invalid backend type\n", stderr);
@@ -213,7 +214,7 @@ main(int argc, char **argv)
 	bound_lens = (int *) g_malloc(table->num_cols * sizeof(int));
 	for (i = 0; i < table->num_cols; i++) {
 		/* bind columns */
-		bound_values[i] = (char *) g_malloc0(MDB_BIND_SIZE);
+		bound_values[i] = (char *) g_malloc0(EXPORT_BIND_SIZE);
 		mdb_bind_column(table, i + 1, bound_values[i], &bound_lens[i]);
 	}
 	if (header_row) {

--- a/src/util/mdb-json.c
+++ b/src/util/mdb-json.c
@@ -20,8 +20,7 @@
 
 #include "base64.h"
 
-#undef MDB_BIND_SIZE
-#define MDB_BIND_SIZE 200000
+#define EXPORT_BIND_SIZE 200000
 
 #define is_quote_type(x) (x==MDB_TEXT || x==MDB_OLE || x==MDB_MEMO || x==MDB_DATETIME || x==MDB_BINARY || x==MDB_REPID)
 #define is_binary_type(x) (x==MDB_OLE || x==MDB_BINARY || x==MDB_REPID)
@@ -144,6 +143,8 @@ main(int argc, char **argv)
 	if (date_fmt)
 		mdb_set_date_fmt(mdb, date_fmt);
 
+    mdb_set_bind_size(mdb, EXPORT_BIND_SIZE);
+
 	table = mdb_read_table_by_name(mdb, argv[2], MDB_TABLE);
 	if (!table) {
 		fprintf(stderr, "Error: Table %s does not exist in this database.\n", argv[argc-1]);
@@ -159,7 +160,7 @@ main(int argc, char **argv)
 	bound_lens = (int *) g_malloc(table->num_cols * sizeof(int));
 	for (i=0;i<table->num_cols;i++) {
 		/* bind columns */
-		bound_values[i] = (char *) g_malloc0(MDB_BIND_SIZE);
+		bound_values[i] = (char *) g_malloc0(EXPORT_BIND_SIZE);
 		mdb_bind_column(table, i+1, bound_values[i], &bound_lens[i]);
 	}
 

--- a/src/util/mdb-queries.c
+++ b/src/util/mdb-queries.c
@@ -33,8 +33,7 @@
 	
 #include "mdbtools.h"
 
-#undef MDB_BIND_SIZE
-#define MDB_BIND_SIZE 200000
+#define QUERY_BIND_SIZE 200000
 
 void mdb_list_queries(MdbHandle *mdb, int line_break, char *delimiter);
 char * mdb_get_query_id(MdbHandle *mdb,char *query);
@@ -50,21 +49,22 @@ int main (int argc, char **argv) {
 	int line_break=0;
 	int opt;	
 	char *query_id;
+    size_t bind_size = QUERY_BIND_SIZE;
 	
 	// variables for the msysqueries table. hopefully 256 is big enough
-	char *attribute = (char *) malloc(MDB_BIND_SIZE);
-	char *expression = (char *) malloc(MDB_BIND_SIZE);
-	char *flag = (char *) malloc(MDB_BIND_SIZE);
-	char *name1 = (char *) malloc(MDB_BIND_SIZE);
-	char *name2 = (char *) malloc(MDB_BIND_SIZE);
-	char *objectid = (char *) malloc(MDB_BIND_SIZE);
-	char *order = (char *) malloc(MDB_BIND_SIZE);
+	char *attribute = (char *) malloc(bind_size);
+	char *expression = (char *) malloc(bind_size);
+	char *flag = (char *) malloc(bind_size);
+	char *name1 = (char *) malloc(bind_size);
+	char *name2 = (char *) malloc(bind_size);
+	char *objectid = (char *) malloc(bind_size);
+	char *order = (char *) malloc(bind_size);
 	
 	//variables for the generation of sql
-	char *sql_tables = (char *) malloc(MDB_BIND_SIZE);
-	char *sql_columns = (char *) malloc(MDB_BIND_SIZE);
-	char *sql_where = (char *) malloc(MDB_BIND_SIZE);
-	char *sql_sorting = (char *) malloc(MDB_BIND_SIZE);
+	char *sql_tables = (char *) malloc(bind_size);
+	char *sql_columns = (char *) malloc(bind_size);
+	char *sql_where = (char *) malloc(bind_size);
+	char *sql_sorting = (char *) malloc(bind_size);
 	
 	/* see getopt(3) for more information on getopt and this will become clear */
 	while ((opt=getopt(argc, argv, "L1d:"))!=-1) {
@@ -101,6 +101,8 @@ int main (int argc, char **argv) {
 		fprintf(stderr,"Couldn't open database.\n");
 		exit(1);
 	}
+
+    mdb_set_bind_size(mdb, bind_size);
 
  	/* read the catalog */
  	if (!mdb_read_catalog (mdb, MDB_ANY)) {


### PR DESCRIPTION
This should fix long-standing complaints about the default bind size without causing undue memory inflation in existing applications.

Could make this adjustable on the command line later.

Supersedes https://github.com/mdbtools/mdbtools/pull/137